### PR TITLE
MT-2609 - Fetch all customer invoices

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,7 +8,6 @@ TEST_TENANT_ID="your_tenant_id"
 # Test data
 TEST_CUSTOMER_CD="test_customer_number"
 TEST_CUSTOMER_INVOICE_NUMBER="test_customer_invoice_number"
-TEST_ATTACHMENT_ID="test_attachment_id"
 
 # Enable to see debug output
 DEBUG="true"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ req.SetQueryParams(GetCustomerInvoiceV1QueryParams{
     DocumentType: "invoice",
     Status: "open",
 })
-resp, err := req.Do()
+resp, err := req.DoAll()
 if err != nil {
 	if resp.StatusCode() == http.StatusNotFound {
 		fmt.Println("Invoices not found")

--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ if err != nil {
 fmt.Println("Invoice retrieved successfully:", resp.Customer.Number)
 ```
 
+### GET `/v1/customerinvoice`
+
+Get all customer invoices for filter.
+
+```go
+req := testClient.NewGetCustomerInvoiceV1Request()
+req.SetQueryParams(GetCustomerInvoiceV1QueryParams{
+	// Example values, for fetching all open invoices
+    DocumentType: "invoice",
+    Status: "open",
+})
+resp, err := req.Do()
+if err != nil {
+	if resp.StatusCode() == http.StatusNotFound {
+		fmt.Println("Invoices not found")
+	} else {
+		fmt.Println("Error getting invoices:", err)
+	}
+}
+fmt.Println("Invoices retrieved successfully:", len(resp.CustomerInvoices))
+```
+
 ### DELETE `/v1/customerinvoice/{invoiceNumber}`
 
 Delete a customer invoice with a specific invoice number.

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -1,12 +1,11 @@
 package vismanet
 
 import (
-	"os"
 	"testing"
 )
 
 func TestPutAttachmentV1(t *testing.T) {
-	id := os.Getenv("TEST_ATTACHMENT_ID")
+	id := uploadTestAttachment(t)
 	req := testClient.NewPutAttachmentV1Request()
 	req.SetPathParams(PutAttachmentV1PathParams{id})
 	req.SetBody(RequestAttachment{SendToAutoInvoice: true})

--- a/client.go
+++ b/client.go
@@ -11,6 +11,10 @@ import (
 	"time"
 )
 
+// DefaultConcurrency is the worker-pool size DoAll-style paged fetches use when
+// Client.Concurrency is unset. Kept small as a conservative default for a rate-limited API.
+const DefaultConcurrency = 5
+
 // NewClient returns a new Visma Net client either using the specified http.Client, or if nil the default http.Client.
 func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
@@ -26,21 +30,23 @@ func NewClient(httpClient *http.Client) *Client {
 			Host:   "api.finance.visma.net",
 			Path:   "/",
 		},
-		Debug:     false,
-		DebugBody: true,
-		UserAgent: UserAgent,
-		Charset:   "utf-8",
+		Debug:       false,
+		DebugBody:   true,
+		UserAgent:   UserAgent,
+		Charset:     "utf-8",
+		Concurrency: DefaultConcurrency,
 	}
 }
 
 // Client is a Visma Net client for making Visma Net API requests.
 type Client struct {
-	Http      *http.Client // Http is the http client used to make requests
-	BaseURL   url.URL      // BaseURL is the base URL of the Visma Net API
-	Debug     bool         // Debug enables debugging output of requests and responses
-	DebugBody bool         // DebugBody enables debugging output of request and response bodies
-	UserAgent string       // UserAgent is the string used in the User-Agent header in requests
-	Charset   string       // Charset is the character set used in the Content-Type header in requests
+	Http        *http.Client // Http is the http client used to make requests
+	BaseURL     url.URL      // BaseURL is the base URL of the Visma Net API
+	Debug       bool         // Debug enables debugging output of requests and responses
+	DebugBody   bool         // DebugBody enables debugging output of request and response bodies
+	UserAgent   string       // UserAgent is the string used in the User-Agent header in requests
+	Charset     string       // Charset is the character set used in the Content-Type header in requests
+	Concurrency int          // Concurrency is the max number of concurrent page requests for paged fetches (DoAll); DefaultConcurrency if <= 0
 }
 
 // Do the API request and decode the response body into the provided interface

--- a/invoice.go
+++ b/invoice.go
@@ -373,8 +373,11 @@ func (r *GetCustomerInvoiceV1Request) Do() (GetCustomerInvoiceV1Response, error)
 // caller-set query parameters (documentType, status, ...) are preserved on every page; a
 // caller-set page size is ignored.
 func (r *GetCustomerInvoiceV1Request) DoAll() (GetCustomerInvoiceV1Response, error) {
-	base, _ := r.queryParams.(GetCustomerInvoiceV1QueryParams)
-	base.PageSize = 0 // always fetch at the API's default page size
+	var base GetCustomerInvoiceV1QueryParams
+	if r.queryParams != nil {
+		base = r.queryParams.(GetCustomerInvoiceV1QueryParams) // panics if queryParams is non-nil and wrong type
+	}
+	base.PageSize = 0
 
 	// fetchPage runs an independent request for a single page. Each call builds its own request so
 	// pages can be fetched concurrently without sharing (and racing on) the receiver.

--- a/invoice.go
+++ b/invoice.go
@@ -1,6 +1,9 @@
 package vismanet
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // ResponseInvoice is an invoice as represented in a response from the Visma.net API
 type ResponseInvoice struct {
@@ -363,52 +366,76 @@ func (r *GetCustomerInvoiceV1Request) Do() (GetCustomerInvoiceV1Response, error)
 }
 
 // DoAll performs the request across all result pages and returns every invoice combined into a
-// single response. It issues the first request to discover the total record count and the server's
-// maximum page size (both reported in each invoice's metadata), then fetches the remaining pages.
-// Any caller-set query parameters (documentType, status, ...) are preserved on every page.
+// single response, in page order. It always fetches at the API's default page size. An initial
+// "find" request retrieves page 1 to read the total count and page size from the metadata; the
+// remaining pages are then fetched by a fixed pool of at most Client.Concurrency workers (default
+// DefaultConcurrency), so the concurrency is bounded and independent of the number of pages. Any
+// caller-set query parameters (documentType, status, ...) are preserved on every page; a
+// caller-set page size is ignored.
 func (r *GetCustomerInvoiceV1Request) DoAll() (GetCustomerInvoiceV1Response, error) {
-	params, _ := r.queryParams.(GetCustomerInvoiceV1QueryParams)
+	base, _ := r.queryParams.(GetCustomerInvoiceV1QueryParams)
+	base.PageSize = 0 // always fetch at the API's default page size
 
-	// Fetch the first page to discover the total count and the maximum page size.
-	params.PageNumber = 1
-	r.SetQueryParams(params)
-	first, err := r.Do()
+	// fetchPage runs an independent request for a single page. Each call builds its own request so
+	// pages can be fetched concurrently without sharing (and racing on) the receiver.
+	fetchPage := func(page int) (GetCustomerInvoiceV1Response, error) {
+		params := base
+		params.PageNumber = page
+		req := r.Client.NewGetCustomerInvoiceV1Request()
+		req.SetQueryParams(params)
+		return req.Do()
+	}
+
+	// Initial find: fetch page 1 to discover the total count and the page size from the metadata.
+	first, err := fetchPage(1)
 	if err != nil || len(first.Invoices) == 0 {
 		return first, err
 	}
 	meta := first.Invoices[0].Metadata
 
-	// Paginate at the caller's page size when set and within bounds, otherwise at the maximum. The
-	// API's default page size equals maxPageSize, so an unset size means page 1 was fetched at it.
-	pageSize := params.PageSize
-	if pageSize <= 0 || pageSize > meta.MaxPageSize {
-		pageSize = meta.MaxPageSize
-	}
+	// The default page size equals maxPageSize, so that is how many records each page holds.
+	pageSize := meta.MaxPageSize
 	if pageSize <= 0 {
 		// No usable page size reported; return the single page we already have.
 		return first, nil
 	}
-
-	// The discovery response already holds page 1 at the size we're paginating with, so reuse it and
-	// continue from page 2. Only a caller-requested size above the maximum makes page 1 use a
-	// different size, in which case re-fetch from page 1.
-	invoices := first.Invoices
-	page := 2
-	if params.PageSize > meta.MaxPageSize {
-		invoices = nil
-		page = 1
+	pages := (meta.TotalCount + pageSize - 1) / pageSize
+	if pages <= 1 {
+		return first, nil
 	}
 
-	pages := (meta.TotalCount + pageSize - 1) / pageSize
-	for ; page <= pages; page++ {
-		params.PageNumber = page
-		params.PageSize = pageSize
-		r.SetQueryParams(params)
-		resp, err := r.Do()
-		if err != nil {
-			return GetCustomerInvoiceV1Response{first.Response, invoices}, err
+	// Fetch the remaining pages (2..pages) with a fixed pool of at most `concurrency` workers. A
+	// buffered channel acts as the semaphore; acquiring before launching each goroutine bounds both
+	// the in-flight requests and the number of live goroutines, so neither scales with page count.
+	// Each worker writes to its own slot, so results stay in page order and require no locking.
+	concurrency := r.Client.Concurrency
+	if concurrency <= 0 {
+		concurrency = DefaultConcurrency
+	}
+	pageInvoices := make([][]ResponseInvoice, pages+1)
+	pageErrs := make([]error, pages+1)
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for page := 2; page <= pages; page++ {
+		wg.Add(1)
+		sem <- struct{}{} // acquire; blocks once `concurrency` fetches are in flight
+		go func(page int) {
+			defer wg.Done()
+			defer func() { <-sem }() // release
+			resp, err := fetchPage(page)
+			pageInvoices[page] = resp.Invoices
+			pageErrs[page] = err
+		}(page)
+	}
+	wg.Wait()
+
+	// Assemble in page order, surfacing the first error along with the invoices gathered so far.
+	invoices := first.Invoices
+	for page := 2; page <= pages; page++ {
+		if pageErrs[page] != nil {
+			return GetCustomerInvoiceV1Response{first.Response, invoices}, pageErrs[page]
 		}
-		invoices = append(invoices, resp.Invoices...)
+		invoices = append(invoices, pageInvoices[page]...)
 	}
 
 	return GetCustomerInvoiceV1Response{first.Response, invoices}, nil

--- a/invoice.go
+++ b/invoice.go
@@ -329,7 +329,9 @@ func newGetCustomerInvoiceV1Request(c *Client) GetCustomerInvoiceV1Request {
 	return GetCustomerInvoiceV1Request{
 		Client: c,
 		Method: "GET",
-		Path:   "v1/customerinvoice/{{.invoice_number}}",
+		// The invoice number segment is only added when set, so the same request can either
+		// fetch a single invoice by number or list/filter invoices via query parameters.
+		Path: "v1/customerinvoice{{if .invoice_number}}/{{.invoice_number}}{{end}}",
 	}
 }
 
@@ -339,6 +341,11 @@ type GetCustomerInvoiceV1Request Request
 // SetPathParams sets the path parameters of the request
 func (r *GetCustomerInvoiceV1Request) SetPathParams(params GetCustomerInvoiceV1PathParams) {
 	r.pathParams = params
+}
+
+// SetQueryParams sets the query parameters of the request
+func (r *GetCustomerInvoiceV1Request) SetQueryParams(params GetCustomerInvoiceV1QueryParams) {
+	r.queryParams = params
 }
 
 // Do performs the request and returns the response
@@ -355,9 +362,70 @@ func (r *GetCustomerInvoiceV1Request) Do() (GetCustomerInvoiceV1Response, error)
 	return GetCustomerInvoiceV1Response{Response{resp}, invoices}, err
 }
 
+// DoAll performs the request across all result pages and returns every invoice combined into a
+// single response. It issues the first request to discover the total record count and the server's
+// maximum page size (both reported in each invoice's metadata), then fetches the remaining pages.
+// Any caller-set query parameters (documentType, status, ...) are preserved on every page.
+func (r *GetCustomerInvoiceV1Request) DoAll() (GetCustomerInvoiceV1Response, error) {
+	params, _ := r.queryParams.(GetCustomerInvoiceV1QueryParams)
+
+	// Fetch the first page to discover the total count and the maximum page size.
+	params.PageNumber = 1
+	r.SetQueryParams(params)
+	first, err := r.Do()
+	if err != nil || len(first.Invoices) == 0 {
+		return first, err
+	}
+	meta := first.Invoices[0].Metadata
+
+	// Paginate at the caller's page size when set and within bounds, otherwise at the maximum. The
+	// API's default page size equals maxPageSize, so an unset size means page 1 was fetched at it.
+	pageSize := params.PageSize
+	if pageSize <= 0 || pageSize > meta.MaxPageSize {
+		pageSize = meta.MaxPageSize
+	}
+	if pageSize <= 0 {
+		// No usable page size reported; return the single page we already have.
+		return first, nil
+	}
+
+	// The discovery response already holds page 1 at the size we're paginating with, so reuse it and
+	// continue from page 2. Only a caller-requested size above the maximum makes page 1 use a
+	// different size, in which case re-fetch from page 1.
+	invoices := first.Invoices
+	page := 2
+	if params.PageSize > meta.MaxPageSize {
+		invoices = nil
+		page = 1
+	}
+
+	pages := (meta.TotalCount + pageSize - 1) / pageSize
+	for ; page <= pages; page++ {
+		params.PageNumber = page
+		params.PageSize = pageSize
+		r.SetQueryParams(params)
+		resp, err := r.Do()
+		if err != nil {
+			return GetCustomerInvoiceV1Response{first.Response, invoices}, err
+		}
+		invoices = append(invoices, resp.Invoices...)
+	}
+
+	return GetCustomerInvoiceV1Response{first.Response, invoices}, nil
+}
+
 // GetCustomerInvoiceV1PathParams represents the path parameters of the GetCustomerInvoiceV1Request
 type GetCustomerInvoiceV1PathParams struct {
 	InvoiceNumber string `schema:"invoice_number"`
+}
+
+// GetCustomerInvoiceV1QueryParams represents the query parameters of the GetCustomerInvoiceV1Request.
+// Zero-value fields are omitted from the request URL.
+type GetCustomerInvoiceV1QueryParams struct {
+	DocumentType string `schema:"documentType"`
+	Status       string `schema:"status"`
+	PageNumber   int    `schema:"pageNumber"`
+	PageSize     int    `schema:"pageSize"`
 }
 
 // GetCustomerInvoiceV1Response represents the response of the GetCustomerInvoiceV1Request and contains the resulting invoices

--- a/invoice.go
+++ b/invoice.go
@@ -2,6 +2,7 @@ package vismanet
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 )
 
@@ -375,7 +376,11 @@ func (r *GetCustomerInvoiceV1Request) Do() (GetCustomerInvoiceV1Response, error)
 func (r *GetCustomerInvoiceV1Request) DoAll() (GetCustomerInvoiceV1Response, error) {
 	var base GetCustomerInvoiceV1QueryParams
 	if r.queryParams != nil {
-		base = r.queryParams.(GetCustomerInvoiceV1QueryParams) // panics if queryParams is non-nil and wrong type
+		tempBase, ok := r.queryParams.(GetCustomerInvoiceV1QueryParams)
+		if !ok {
+			return GetCustomerInvoiceV1Response{}, fmt.Errorf("invalid query parameters: %T", r.queryParams)
+		}
+		base = tempBase
 	}
 	base.PageSize = 0
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -1,10 +1,153 @@
 package vismanet
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"strconv"
+	"sync/atomic"
 	"testing"
 )
+
+func TestGetCustomerInvoiceV1URL(t *testing.T) {
+	c := NewClient(nil)
+
+	// Do() defaults empty path params before building the URL, so the {{if .invoice_number}}
+	// segment resolves. These cases call url() directly to stay offline, so they mimic that guard.
+	buildURL := func(req GetCustomerInvoiceV1Request) (string, error) {
+		if (*Request)(&req).pathParams == nil {
+			req.SetPathParams(GetCustomerInvoiceV1PathParams{})
+		}
+		return (*Request)(&req).url()
+	}
+
+	// With query parameters set and no invoice number, the request targets the list/filter endpoint.
+	list := c.NewGetCustomerInvoiceV1Request()
+	list.SetQueryParams(GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open"})
+	got, err := buildURL(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://api.finance.visma.net/v1/customerinvoice?documentType=Invoice&status=Open"; got != want {
+		t.Errorf("list URL: expected %q, got %q", want, got)
+	}
+
+	// With an invoice number set, the request targets a single invoice and sends no query string.
+	single := c.NewGetCustomerInvoiceV1Request()
+	single.SetPathParams(GetCustomerInvoiceV1PathParams{InvoiceNumber: "12345"})
+	got, err = buildURL(single)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://api.finance.visma.net/v1/customerinvoice/12345"; got != want {
+		t.Errorf("single URL: expected %q, got %q", want, got)
+	}
+
+	// Empty query fields must be omitted entirely.
+	partial := c.NewGetCustomerInvoiceV1Request()
+	partial.SetQueryParams(GetCustomerInvoiceV1QueryParams{Status: "Open"})
+	got, err = buildURL(partial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://api.finance.visma.net/v1/customerinvoice?status=Open"; got != want {
+		t.Errorf("partial URL: expected %q, got %q", want, got)
+	}
+
+	// Integer pagination params are rendered, and zero values omitted.
+	paged := c.NewGetCustomerInvoiceV1Request()
+	paged.SetQueryParams(GetCustomerInvoiceV1QueryParams{Status: "Open", PageNumber: 2, PageSize: 1000})
+	got, err = buildURL(paged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://api.finance.visma.net/v1/customerinvoice?pageNumber=2&pageSize=1000&status=Open"; got != want {
+		t.Errorf("paged URL: expected %q, got %q", want, got)
+	}
+}
+
+func TestGetCustomerInvoiceV1DoAll(t *testing.T) {
+	const totalCount, maxPageSize = 7, 3
+
+	// Serves the customerinvoice list endpoint with pagination and metadata, so DoAll can be
+	// exercised without hitting the live API. The API's default page size equals maxPageSize.
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		q := req.URL.Query()
+
+		// The caller's filters must be preserved on every page.
+		if q.Get("documentType") != "Invoice" || q.Get("status") != "Open" {
+			t.Errorf("missing filters on request %s", req.URL.String())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		pageNumber, _ := strconv.Atoi(q.Get("pageNumber"))
+		if pageNumber == 0 {
+			pageNumber = 1
+		}
+		pageSize, _ := strconv.Atoi(q.Get("pageSize"))
+		if pageSize == 0 || pageSize > maxPageSize {
+			pageSize = maxPageSize
+		}
+
+		start := (pageNumber - 1) * pageSize
+		end := start + pageSize
+		if end > totalCount {
+			end = totalCount
+		}
+
+		invoices := []map[string]interface{}{}
+		for i := start; i < end; i++ {
+			invoices = append(invoices, map[string]interface{}{
+				"referenceNumber": fmt.Sprintf("INV-%d", i+1),
+				"metadata":        map[string]int{"totalCount": totalCount, "maxPageSize": maxPageSize},
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(invoices)
+	}))
+	defer server.Close()
+
+	srvURL, _ := url.Parse(server.URL)
+	c := NewClient(nil)
+	c.BaseURL = url.URL{Scheme: srvURL.Scheme, Host: srvURL.Host, Path: "/"}
+
+	assertAll := func(name string, params GetCustomerInvoiceV1QueryParams) {
+		atomic.StoreInt32(&requests, 0)
+
+		req := c.NewGetCustomerInvoiceV1Request()
+		req.SetQueryParams(params)
+		resp, err := req.DoAll()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+
+		if len(resp.Invoices) != totalCount {
+			t.Fatalf("%s: expected %d invoices, got %d", name, totalCount, len(resp.Invoices))
+		}
+		for i, inv := range resp.Invoices {
+			if want := fmt.Sprintf("INV-%d", i+1); inv.ReferenceNumber != want {
+				t.Errorf("%s: invoice %d: expected %s, got %s", name, i, want, inv.ReferenceNumber)
+			}
+		}
+
+		// 3 pages, none fetched twice: the discovery response is reused rather than re-fetched.
+		if got := atomic.LoadInt32(&requests); got != 3 {
+			t.Errorf("%s: expected 3 requests, got %d", name, got)
+		}
+	}
+
+	// Page size unset: the default page size equals maxPageSize, so the discovery page is reused.
+	assertAll("default page size", GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open"})
+	// Page size set to the max: same reuse behavior.
+	assertAll("explicit page size", GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open", PageSize: 3})
+}
 
 func TestGetCustomerInvoiceV1(t *testing.T) {
 	invoiceNumber := os.Getenv("TEST_CUSTOMER_INVOICE_NUMBER")

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestGetCustomerInvoiceV1URL(t *testing.T) {
@@ -137,16 +138,95 @@ func TestGetCustomerInvoiceV1DoAll(t *testing.T) {
 			}
 		}
 
-		// 3 pages, none fetched twice: the discovery response is reused rather than re-fetched.
+		// 1 discovery request + 2 concurrent page fetches = 3; no page is fetched twice.
 		if got := atomic.LoadInt32(&requests); got != 3 {
 			t.Errorf("%s: expected 3 requests, got %d", name, got)
 		}
 	}
 
-	// Page size unset: the default page size equals maxPageSize, so the discovery page is reused.
+	// Page size unset: fetches at the default page size (== maxPageSize).
 	assertAll("default page size", GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open"})
-	// Page size set to the max: same reuse behavior.
-	assertAll("explicit page size", GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open", PageSize: 3})
+	// A caller-set page size is ignored: pageSize 2 would need 4 requests if honored, but DoAll
+	// still makes 3 because it always uses the default.
+	assertAll("page size ignored", GetCustomerInvoiceV1QueryParams{DocumentType: "Invoice", Status: "Open", PageSize: 2})
+}
+
+// TestGetCustomerInvoiceV1DoAllConcurrencyBound verifies DoAll never runs more than
+// Client.Concurrency page fetches at once, regardless of how many pages there are. The handler
+// tracks concurrent in-flight requests and records the high-water mark; a small delay widens the
+// window so overlapping requests are observed. With 10 pages and Concurrency 2, an unbounded
+// fan-out would peak near 9; the bounded pool must keep the peak at Concurrency.
+func TestGetCustomerInvoiceV1DoAllConcurrencyBound(t *testing.T) {
+	const totalCount, maxPageSize, concurrency = 20, 2, 2
+
+	var inFlight, maxInFlight int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Record the high-water mark of concurrent requests.
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			old := atomic.LoadInt32(&maxInFlight)
+			if cur <= old || atomic.CompareAndSwapInt32(&maxInFlight, old, cur) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond) // widen the overlap window
+		defer atomic.AddInt32(&inFlight, -1)
+
+		q := req.URL.Query()
+		pageNumber, _ := strconv.Atoi(q.Get("pageNumber"))
+		if pageNumber == 0 {
+			pageNumber = 1
+		}
+		pageSize, _ := strconv.Atoi(q.Get("pageSize"))
+		if pageSize == 0 || pageSize > maxPageSize {
+			pageSize = maxPageSize
+		}
+
+		start := (pageNumber - 1) * pageSize
+		end := start + pageSize
+		if end > totalCount {
+			end = totalCount
+		}
+
+		invoices := []map[string]interface{}{}
+		for i := start; i < end; i++ {
+			invoices = append(invoices, map[string]interface{}{
+				"referenceNumber": fmt.Sprintf("INV-%d", i+1),
+				"metadata":        map[string]int{"totalCount": totalCount, "maxPageSize": maxPageSize},
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(invoices)
+	}))
+	defer server.Close()
+
+	srvURL, _ := url.Parse(server.URL)
+	c := NewClient(nil)
+	c.BaseURL = url.URL{Scheme: srvURL.Scheme, Host: srvURL.Host, Path: "/"}
+	c.Concurrency = concurrency
+
+	req := c.NewGetCustomerInvoiceV1Request()
+	resp, err := req.DoAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All pages still fetched exactly once, in order.
+	if len(resp.Invoices) != totalCount {
+		t.Fatalf("expected %d invoices, got %d", totalCount, len(resp.Invoices))
+	}
+	for i, inv := range resp.Invoices {
+		if want := fmt.Sprintf("INV-%d", i+1); inv.ReferenceNumber != want {
+			t.Errorf("invoice %d: expected %s, got %s", i, want, inv.ReferenceNumber)
+		}
+	}
+
+	// The discovery request completes before fan-out begins, so the peak should equal Concurrency;
+	// allow +1 as slack against any scheduling overlap.
+	if got := atomic.LoadInt32(&maxInFlight); got > concurrency+1 {
+		t.Errorf("peak concurrent requests %d exceeded Concurrency %d (+1 slack)", got, concurrency)
+	}
 }
 
 func TestGetCustomerInvoiceV1(t *testing.T) {

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -222,10 +222,9 @@ func TestGetCustomerInvoiceV1DoAllConcurrencyBound(t *testing.T) {
 		}
 	}
 
-	// The discovery request completes before fan-out begins, so the peak should equal Concurrency;
-	// allow +1 as slack against any scheduling overlap.
-	if got := atomic.LoadInt32(&maxInFlight); got > concurrency+1 {
-		t.Errorf("peak concurrent requests %d exceeded Concurrency %d (+1 slack)", got, concurrency)
+	// The discovery request completes before fan-out begins, so the peak should equal Concurrency.
+	if got := atomic.LoadInt32(&maxInFlight); got > concurrency {
+		t.Errorf("peak concurrent requests %d exceeded Concurrency %d", got, concurrency)
 	}
 }
 
@@ -292,7 +291,27 @@ func TestDeleteCustomerInvoiceV1(t *testing.T) {
 	}
 }
 
-func TestPostCustomerInvoiceAttachmentV1(t *testing.T) {
+// testPDF is a minimal single-page PDF. The attachment must be a PDF, since
+// the API only allows PDF files to be sent to AutoInvoice.
+const testPDF = `%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000052 00000 n
+0000000101 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+165
+%%EOF`
+
+// uploadTestAttachment uploads a minimal PDF to the invoice in
+// TEST_CUSTOMER_INVOICE_NUMBER and returns the new attachment's ID
+func uploadTestAttachment(t *testing.T) string {
+	t.Helper()
 	req := testClient.NewPostCustomerInvoiceAttachmentV1Request()
 	req.SetPathParams(PostCustomerInvoiceAttachmentV1PathParams{
 		InvoiceNumber: os.Getenv("TEST_CUSTOMER_INVOICE_NUMBER"),
@@ -300,16 +319,21 @@ func TestPostCustomerInvoiceAttachmentV1(t *testing.T) {
 	req.SetBody(FileUploadBody{
 		Files: []File{
 			{
-				Name:    "Test.txt",
-				Content: []byte("test"),
+				Name:    "Test.pdf",
+				Content: []byte(testPDF),
 			},
 		},
 	})
 	resp, err := req.Do()
 	debugDumpResponse(testClient, resp)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	} else if resp.ResourceID() == "" {
-		t.Errorf("Expected non-empty resource ID, got %s", resp.ResourceID())
+		t.Fatalf("Expected non-empty resource ID, got %s", resp.ResourceID())
 	}
+	return resp.ResourceID()
+}
+
+func TestPostCustomerInvoiceAttachmentV1(t *testing.T) {
+	uploadTestAttachment(t)
 }

--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"reflect"
+	"strconv"
 	"text/template"
 )
 
@@ -24,7 +25,7 @@ type Request struct {
 	Method      string
 	Path        string
 	Body        RequestBody
-	queryParams url.Values
+	queryParams interface{}
 	pathParams  interface{}
 }
 
@@ -53,6 +54,38 @@ func (r *Request) pathParamsMap() map[string]string {
 	return params
 }
 
+// queryParamsValues returns the query parameters from the queryParams struct, skipping empty values
+func (r *Request) queryParamsValues() url.Values {
+	values := url.Values{}
+	if r.queryParams == nil {
+		return values
+	}
+
+	//Get the type and value of the query parameters struct
+	t := reflect.TypeOf(r.queryParams)
+	v := reflect.ValueOf(r.queryParams)
+
+	//Iterate over the fields of the query parameters struct and add any non-zero string or int fields with a schema tag
+	for i := 0; i < t.NumField(); i++ {
+		name, ok := t.Field(i).Tag.Lookup("schema")
+		if !ok {
+			continue
+		}
+		switch v.Field(i).Kind() {
+		case reflect.String:
+			if value := v.Field(i).String(); value != "" {
+				values.Set(name, value)
+			}
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if value := v.Field(i).Int(); value != 0 {
+				values.Set(name, strconv.FormatInt(value, 10))
+			}
+		}
+	}
+
+	return values
+}
+
 // url returns the complete URL of the request
 func (r *Request) url() (string, error) {
 	//Parse path template
@@ -67,8 +100,15 @@ func (r *Request) url() (string, error) {
 		return "", err
 	}
 
-	//Return the complete URL
-	return r.Client.BaseURL.String() + buf.String(), nil
+	//Build the complete URL
+	u := r.Client.BaseURL.String() + buf.String()
+
+	//Append query parameters if any
+	if query := r.queryParamsValues(); len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	return u, nil
 }
 
 // build the http request

--- a/request.go
+++ b/request.go
@@ -101,14 +101,15 @@ func (r *Request) url() (string, error) {
 	}
 
 	//Build the complete URL
-	u := r.Client.BaseURL.String() + buf.String()
-
-	//Append query parameters if any
-	if query := r.queryParamsValues(); len(query) > 0 {
-		u += "?" + query.Encode()
+	u, err := url.Parse(r.Client.BaseURL.String() + buf.String())
+	if err != nil {
+		return "", err
 	}
 
-	return u, nil
+	//Set query parameters
+	u.RawQuery = r.queryParamsValues().Encode()
+
+	return u.String(), nil
 }
 
 // build the http request

--- a/request.go
+++ b/request.go
@@ -80,6 +80,8 @@ func (r *Request) queryParamsValues() url.Values {
 			if value := v.Field(i).Int(); value != 0 {
 				values.Set(name, strconv.FormatInt(value, 10))
 			}
+		default:
+			panic(fmt.Sprintf("unsupported query parameter type: %s", t.Field(i).Type.String()))
 		}
 	}
 

--- a/request.go
+++ b/request.go
@@ -55,10 +55,10 @@ func (r *Request) pathParamsMap() map[string]string {
 }
 
 // queryParamsValues returns the query parameters from the queryParams struct, skipping empty values
-func (r *Request) queryParamsValues() url.Values {
+func (r *Request) queryParamsValues() (url.Values, error) {
 	values := url.Values{}
 	if r.queryParams == nil {
-		return values
+		return values, nil
 	}
 
 	//Get the type and value of the query parameters struct
@@ -81,11 +81,11 @@ func (r *Request) queryParamsValues() url.Values {
 				values.Set(name, strconv.FormatInt(value, 10))
 			}
 		default:
-			panic(fmt.Sprintf("unsupported query parameter type: %s", t.Field(i).Type.String()))
+			return nil, fmt.Errorf("unsupported query parameter type %s in field %s", t.Field(i).Type.String(), t.Field(i).Name)
 		}
 	}
 
-	return values
+	return values, nil
 }
 
 // url returns the complete URL of the request
@@ -109,7 +109,11 @@ func (r *Request) url() (string, error) {
 	}
 
 	//Set query parameters
-	u.RawQuery = r.queryParamsValues().Encode()
+	queryValues, err := r.queryParamsValues()
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = queryValues.Encode()
 
 	return u.String(), nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CustomerInvoice retrieval with optional invoice-number targeting plus `DocumentType`/`Status` filters and pagination controls.
  * Added `DoAll` to fetch all CustomerInvoices across pages, preserving filters and using client-configured bounded concurrency.
  * Introduced a client `Concurrency` setting (with a default when unset).
* **Bug Fixes**
  * Improved request URL building to reliably encode query parameters and omit empty/zero values.
* **Documentation**
  * Updated README with a `GET /v1/customerinvoice` example using filters and `DoAll`.
* **Tests**
  * Added URL and `DoAll` pagination/concurrency tests; updated attachment tests to use a minimal PDF input.
* **Chores**
  * Removed `TEST_ATTACHMENT_ID` from the env template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->